### PR TITLE
Add bind9-utils to container and update to Devian Trixie

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -61,7 +61,7 @@ jobs:
       image: flobernd/haproxy-acme
       context: ./haproxy-acme/data
       build-args: |
-        BASE_IMAGE=haproxy:${{ inputs.version-major }}.${{ inputs.version-minor }}-bookworm
+        BASE_IMAGE=haproxy:${{ inputs.version-major }}.${{ inputs.version-minor }}-trixie
       platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/mips64le", "linux/ppc64le", "linux/s390x"]'
       tags: |
         ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}.${{ inputs.version-minor }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -62,7 +62,7 @@ jobs:
       context: ./haproxy-acme/data
       build-args: |
         BASE_IMAGE=haproxy:${{ inputs.version-major }}.${{ inputs.version-minor }}-trixie
-      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/mips64le", "linux/ppc64le", "linux/s390x"]'
+      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/ppc64le", "linux/s390x"]'
       tags: |
         ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}.${{ inputs.version-minor }}
         ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}
@@ -86,7 +86,7 @@ jobs:
       context: ./haproxy-acme-http01/data
       build-args: |
         BASE_IMAGE=ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}.${{ inputs.version-minor }}
-      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/mips64le", "linux/ppc64le", "linux/s390x"]'
+      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/ppc64le", "linux/s390x"]'
       tags: |
         ghcr.io/flobernd/haproxy-acme-http01:${{ inputs.version-major }}.${{ inputs.version-minor }}
         ghcr.io/flobernd/haproxy-acme-http01:${{ inputs.version-major }}
@@ -110,7 +110,7 @@ jobs:
       context: ./haproxy-acme-dns01/data
       build-args: |
         BASE_IMAGE=ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}.${{ inputs.version-minor }}
-      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/mips64le", "linux/ppc64le", "linux/s390x"]'
+      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/ppc64le", "linux/s390x"]'
       tags: |
         ghcr.io/flobernd/haproxy-acme-dns01:${{ inputs.version-major }}.${{ inputs.version-minor }}
         ghcr.io/flobernd/haproxy-acme-dns01:${{ inputs.version-major }}
@@ -134,7 +134,7 @@ jobs:
       context: ./haproxy-acme-tlsalpn01/data
       build-args: |
         BASE_IMAGE=ghcr.io/flobernd/haproxy-acme:${{ inputs.version-major }}.${{ inputs.version-minor }}
-      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/mips64le", "linux/ppc64le", "linux/s390x"]'
+      platforms: '["linux/386", "linux/amd64", "linux/arm/v5", "linux/arm/v7", "linux/arm64", "linux/ppc64le", "linux/s390x"]'
       tags: |
         ghcr.io/flobernd/haproxy-acme-tlsalpn01:${{ inputs.version-major }}.${{ inputs.version-minor }}
         ghcr.io/flobernd/haproxy-acme-tlsalpn01:${{ inputs.version-major }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x
+          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           build-args: |
             BASE_IMAGE=${{ env.BASE_IMAGE }}
           tags: ${{ steps.meta-haproxy-acme.outputs.tags }}
@@ -87,7 +87,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x
+          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           build-args: |
             BASE_IMAGE=${{ fromJSON(steps.build-haproxy-acme.outputs.metadata)['image.name'] }}
           tags: ${{ steps.meta-haproxy-acme-http01.outputs.tags }}
@@ -115,7 +115,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x
+          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           build-args: |
             BASE_IMAGE=${{ fromJSON(steps.build-haproxy-acme.outputs.metadata)['image.name'] }}
           tags: ${{ steps.meta-haproxy-acme-dns01.outputs.tags }}
@@ -143,7 +143,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true
-          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/mips64le,linux/ppc64le,linux/s390x
+          # platforms: linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
           build-args: |
             BASE_IMAGE=${{ fromJSON(steps.build-haproxy-acme.outputs.metadata)['image.name'] }}
           tags: ${{ steps.meta-haproxy-acme-tlsalpn01.outputs.tags }}

--- a/haproxy-acme/data/Dockerfile
+++ b/haproxy-acme/data/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get install -y --no-install-recommends \
         curl \
         socat \
         idn \
-        nsupdate
+        bind9-dnsutils
 
 COPY --chown=haproxy:haproxy supervisord.conf /etc/supervisord.conf
 

--- a/haproxy-acme/data/Dockerfile
+++ b/haproxy-acme/data/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=haproxy:bookworm
+ARG BASE_IMAGE=haproxy:trixie
 
 FROM $BASE_IMAGE
 

--- a/haproxy-acme/data/Dockerfile
+++ b/haproxy-acme/data/Dockerfile
@@ -67,14 +67,15 @@ RUN echo '. "/usr/local/share/acme/acme.sh.env"' >> /var/lib/haproxy/.bashrc && 
     chown haproxy:haproxy /var/lib/haproxy/.bashrc && \
     chmod 0644 /var/lib/haproxy/.bashrc
 
-# Install 'supervisord' and 'acme.sh' dependencies
+# Install 'supervisord', direct 'acme.sh' dependencies, and 'acme.sh' DNS API dependencies.
 
 RUN apt-get install -y --no-install-recommends \
         supervisor \
         ca-certificates \
         curl \
         socat \
-        idn
+        idn \
+        nsupdate
 
 COPY --chown=haproxy:haproxy supervisord.conf /etc/supervisord.conf
 


### PR DESCRIPTION
I've added `bind9-utils` to the container for `nsupdate` which, unsurprisingly, is needed by the [dns_nsupdate](https://github.com/acmesh-official/acme.sh/blob/master/dnsapi/dns_nsupdate.sh) DNS API provider.

I have also updated the container to use Debian Trixie which required dropping the mips64le arch as it is no longer officially provided starting with Trixie.

I have tested this working on linux amd64.